### PR TITLE
Refactor: allow for dataset-derived traits from loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ You can load a dataset and its trait profiles natively:
 
 ```python
 from mlwp_data_loaders import load_dataset
+from mlwp_data_specs import validate_dataset
 
+# 1. Load the dataset and extract the trait profiles defined by the loader
 ds, dataset_traits = load_dataset(
     [
         "/path/to/anemoi-inference-20260101T00.nc",
@@ -37,8 +39,16 @@ ds, dataset_traits = load_dataset(
     return_dataset_traits=True,
 )
 
-print(f"Validation time profile used: {dataset_traits['time_profile']}")
-print(f"Dataset has {len(ds.data_vars)} variables.")
+# 2. Get a detailed validation report by passing the extracted traits
+report = validate_dataset(
+    ds,
+    time=dataset_traits.get("time_profile"),
+    space=dataset_traits.get("space_profile"),
+    uncertainty=dataset_traits.get("uncertainty_profile"),
+)
+
+# 3. Print the validation results to the console
+report.console_print()
 ```
 
 If you don't need the traits dictionary returned, simply omit `return_dataset_traits` (defaults to `False`):

--- a/README.md
+++ b/README.md
@@ -7,106 +7,101 @@ Loader package for opening source datasets before validating them with
 
 `mlwp-data-loaders` is responsible for:
 
-1. importing a loader module or script
-2. opening one or more source datasets using loader-defined traits
-3. optionally checking that the chosen trait profiles are compatible with the loader
-4. returning an `xarray.Dataset` that can then be validated with `mlwp-data-specs`
+1. Importing a loader module (or Python file).
+2. Using the loader to open and normalize source datasets.
+3. Extracting the appropriate validation trait profiles (`TIME_PROFILE`, `SPACE_PROFILE`, `UNCERTAINTY_PROFILE`) defined by the loader.
+4. Validating the returned `xarray.Dataset` automatically via `mlwp-data-specs`.
+5. Returning the `xarray.Dataset` (and optionally the trait dict) for further use or machine learning workloads.
 
 The intended split is:
-
-1. `mlwp-data-loaders`: source-specific loading and normalization
-2. `mlwp-data-specs`: trait validation
+- **`mlwp-data-loaders`**: Source-specific loading and normalization logic.
+- **`mlwp-data-specs`**: General trait validation and compliance checks.
 
 ## Python API
 
 The `loader` argument is interpreted as:
+- A Python file path if it ends with `.py`.
+- A Python module path if it contains `.` (e.g. `mlwp_data_loaders.loaders.anemoi.anemoi_inference`).
 
-- a Python file path if it ends with `.py`
-- a Python module path if it contains `.`
-
-Load a dataset through a loader module:
+You can load a dataset and its trait profiles natively:
 
 ```python
 from mlwp_data_loaders import load_dataset
-from mlwp_data_specs import validate_dataset
 
-ds = load_dataset(
+ds, dataset_traits = load_dataset(
     [
         "/path/to/anemoi-inference-20260101T00.nc",
         "/path/to/anemoi-inference-20260102T00.nc",
     ],
     loader="mlwp_data_loaders.loaders.anemoi.anemoi_inference",
-    time="forecast",
-    space="grid",
-    uncertainty="deterministic",
+    return_dataset_traits=True,
 )
 
-report = validate_dataset(
-    ds,
-    time="forecast",
-    space="grid",
-    uncertainty="deterministic",
-)
+print(f"Validation time profile used: {dataset_traits['time_profile']}")
+print(f"Dataset has {len(ds.data_vars)} variables.")
+```
 
-report.console_print()
+If you don't need the traits dictionary returned, simply omit `return_dataset_traits` (defaults to `False`):
+
+```python
+ds = load_dataset(
+    "s3://my-bucket/dataset.zarr",
+    loader="mlwp_data_loaders.loaders.anemoi.anemoi_datasets",
+    storage_options={"anon": True},
+)
 ```
 
 ## CLI
 
-Use the loader-aware CLI:
+Use the loader-aware CLI to load and validate data from the command line:
 
 ```bash
 uv run mlwp.load_and_validate_dataset \
   /path/to/anemoi-inference-20260101T00.nc \
   /path/to/anemoi-inference-20260102T00.nc \
-  --loader mlwp_data_loaders.loaders.anemoi.anemoi_inference \
-  --time forecast \
-  --space grid \
-  --uncertainty deterministic
+  --loader mlwp_data_loaders.loaders.anemoi.anemoi_inference
 ```
 
-Using a user-provided loader script:
+Using a user-provided custom loader script:
 
 ```bash
 uv run mlwp.load_and_validate_dataset \
   /path/to/source-a.nc \
   /path/to/source-b.nc \
-  --loader ./examples/my_loader.py \
-  --time forecast \
-  --space grid \
-  --uncertainty deterministic
+  --loader ./examples/my_loader.py
 ```
 
-## Loader module contract
+## Loader Module Contract
 
-The loader module may define a subset of the following:
+Each loader module must define a function and optionally standard profile variables:
 
-1. Variables defining how each provided path is opened with `xarray.open_dataset`
-   - `OPEN_KWARGS`: keyword arguments forwarded to `xarray.open_dataset`, including backend selection such as `{"engine": "zarr"}` or `{"engine": "h5netcdf"}`
-2. Functions and variables around preprocessing, concatenation, and postprocessing
-   - `preprocess(ds)`: normalize each opened source dataset before combination
-   - `CONCAT_DIM`: dimension used when combining multiple inputs; required if more than one path is provided
-   - `postprocess(ds)`: finalize the combined dataset before validation
-3. Variables defining valid trait profiles
-   - `valid_time_profiles`: allowed `time=` profile values for this loader
-   - `valid_space_profiles`: allowed `space=` profile values for this loader
-   - `valid_uncertainty_profiles`: allowed `uncertainty=` profile values for this loader
+1. `load_dataset(path: str | list[str], **kwargs) -> xr.Dataset`
+   - **Required**. Handles opening the path(s), preprocessing, concatenating, and postprocessing, returning a single normalized `xarray.Dataset`.
+2. `TIME_PROFILE`: `str`
+   - Defines the time trait profile for `mlwp-data-specs` validation (e.g. `"forecast"`).
+3. `SPACE_PROFILE`: `str`
+   - Defines the space trait profile (e.g. `"grid"`).
+4. `UNCERTAINTY_PROFILE`: `str`
+   - Defines the uncertainty trait profile (e.g. `"deterministic"`).
 
-Example:
+### Example Loader (`my_loader.py`)
 
 ```python
 import xarray as xr
 
-OPEN_KWARGS = {}
+TIME_PROFILE = "observation"
+SPACE_PROFILE = "grid"
+UNCERTAINTY_PROFILE = "deterministic"
 
+def load_dataset(path: str | list[str], **kwargs) -> xr.Dataset:
+    if isinstance(path, list):
+        ds = xr.open_mfdataset(path, combine="by_coords", **kwargs)
+    else:
+        ds = xr.open_dataset(path, **kwargs)
 
-def preprocess(ds: xr.Dataset) -> xr.Dataset | xr.DataArray:
-    return ds
+    # Example post-processing
+    if "time" in ds.dims:
+        ds = ds.rename({"time": "valid_time"})
 
-
-CONCAT_DIM = "valid_time"
-
-
-def postprocess(ds: xr.Dataset | xr.DataArray) -> xr.Dataset | xr.DataArray:
     return ds
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Loader package for opening source datasets before validating them with
 
 The intended split is:
 - **`mlwp-data-loaders`** (this repo): Source-specific loading and normalization logic.
-- [**`mlwp-data-specs`**](https://github.com/mlwp-tools/mlwp-data-specs): General trait validation and compliance checks.
+- [**`mlwp-data-specs`**](https://github.com/mlwp-tools/mlwp-data-specs): Trait dataset requirements definitions and validation.
 
 ## Python API
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Each loader module must define a function and assign the correct trait profile a
 
 ```python
 import xarray as xr
-from mlwp_data_loaders.core import SPACE_TRAIT_ATTR, TIME_TRAIT_ATTR, UNCERTAINTY_TRAIT_ATTR
+from mlwp_data_specs.api import SPACE_TRAIT_ATTR, TIME_TRAIT_ATTR, UNCERTAINTY_TRAIT_ATTR
 
 def load_dataset(path: str | list[str], **kwargs) -> xr.Dataset:
     if isinstance(path, list):

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Loader package for opening source datasets before validating them with
 3. Returning the `xarray.Dataset` (and optionally a validation report) for further use or machine learning workloads.
 
 The intended split is:
-- [**`mlwp-data-loaders`**](https://github.com/mlwp-tools/mlwp-data-loaders): Source-specific loading and normalization logic.
+- **`mlwp-data-loaders`** (this repo): Source-specific loading and normalization logic.
 - [**`mlwp-data-specs`**](https://github.com/mlwp-tools/mlwp-data-specs): General trait validation and compliance checks.
 
 ## Python API

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ Loader package for opening source datasets before validating them with
 
 `mlwp-data-loaders` is responsible for:
 
-1. Importing a loader module (or Python file).
-2. Using the loader to open and normalize source files, while [setting global attributes on the resulting dataset](#loader-module-contract) to indicate the [dataset's traits](https://github.com/mlwp-tools/mlwp-data-specs).
-3. Validating the returned dataset automatically via `mlwp-data-specs`.
-4. Returning the `xarray.Dataset` (and optionally a validation report) for further use or machine learning workloads.
+1. Using a given loader module ([bundled with mlwp-data-loaders](src/mlwp_data_loaders/loaders/) or [user-provided](#loader-module-contract)) that defines how to load and normalize source files. The loader is expected to [set global attributes on the resulting dataset](#loader-module-contract) to indicate the [dataset's traits](https://github.com/mlwp-tools/mlwp-data-specs).
+2. Validating the returned dataset automatically via `mlwp-data-specs`.
+3. Returning the `xarray.Dataset` (and optionally a validation report) for further use or machine learning workloads.
 
 The intended split is:
 - **`mlwp-data-loaders`**: Source-specific loading and normalization logic.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Loader package for opening source datasets before validating them with
 3. Returning the `xarray.Dataset` (and optionally a validation report) for further use or machine learning workloads.
 
 The intended split is:
-- **`mlwp-data-loaders`**: Source-specific loading and normalization logic.
-- **`mlwp-data-specs`**: General trait validation and compliance checks.
+- [**`mlwp-data-loaders`**](https://github.com/mlwp-tools/mlwp-data-loaders): Source-specific loading and normalization logic.
+- [**`mlwp-data-specs`**](https://github.com/mlwp-tools/mlwp-data-specs): General trait validation and compliance checks.
 
 ## Python API
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ Loader package for opening source datasets before validating them with
 `mlwp-data-loaders` is responsible for:
 
 1. Importing a loader module (or Python file).
-2. Using the loader to open and normalize source datasets.
-3. Automatically extracting the appropriate validation traits assigned to the returned `xarray.Dataset` by the loader.
-4. Validating the returned dataset automatically via `mlwp-data-specs`.
-5. Returning the `xarray.Dataset` (and optionally a validation report) for further use or machine learning workloads.
+2. Using the loader to open and normalize source files, while [setting global attributes on the resulting dataset](#loader-module-contract) to indicate the [dataset's traits](https://github.com/mlwp-tools/mlwp-data-specs).
+3. Validating the returned dataset automatically via `mlwp-data-specs`.
+4. Returning the `xarray.Dataset` (and optionally a validation report) for further use or machine learning workloads.
 
 The intended split is:
 - **`mlwp-data-loaders`**: Source-specific loading and normalization logic.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Loader package for opening source datasets before validating them with
 
 1. Importing a loader module (or Python file).
 2. Using the loader to open and normalize source datasets.
-3. Extracting the appropriate validation trait profiles (`TIME_PROFILE`, `SPACE_PROFILE`, `UNCERTAINTY_PROFILE`) defined by the loader.
-4. Validating the returned `xarray.Dataset` automatically via `mlwp-data-specs`.
-5. Returning the `xarray.Dataset` (and optionally the trait dict) for further use or machine learning workloads.
+3. Automatically extracting the appropriate validation traits assigned to the returned `xarray.Dataset` by the loader.
+4. Validating the returned dataset automatically via `mlwp-data-specs`.
+5. Returning the `xarray.Dataset` (and optionally a validation report) for further use or machine learning workloads.
 
 The intended split is:
 - **`mlwp-data-loaders`**: Source-specific loading and normalization logic.
@@ -23,38 +23,30 @@ The `loader` argument is interpreted as:
 - A Python file path if it ends with `.py`.
 - A Python module path if it contains `.` (e.g. `mlwp_data_loaders.loaders.anemoi.anemoi_inference`).
 
-You can load a dataset and its trait profiles natively:
+You can load a dataset and get its validation report natively:
 
 ```python
-from mlwp_data_loaders import load_dataset
+from mlwp_data_loaders import load_and_validate_dataset
 from mlwp_data_specs import validate_dataset
 
-# 1. Load the dataset and extract the trait profiles defined by the loader
-ds, dataset_traits = load_dataset(
+# 1. Load the dataset and extract the validation report
+ds, validation_report = load_and_validate_dataset(
     [
         "/path/to/anemoi-inference-20260101T00.nc",
         "/path/to/anemoi-inference-20260102T00.nc",
     ],
     loader="mlwp_data_loaders.loaders.anemoi.anemoi_inference",
-    return_dataset_traits=True,
+    return_validation_report=True,
 )
 
-# 2. Get a detailed validation report by passing the extracted traits
-report = validate_dataset(
-    ds,
-    time=dataset_traits.get("time_profile"),
-    space=dataset_traits.get("space_profile"),
-    uncertainty=dataset_traits.get("uncertainty_profile"),
-)
-
-# 3. Print the validation results to the console
-report.console_print()
+# 2. Print the validation results to the console
+validation_report.console_print()
 ```
 
-If you don't need the traits dictionary returned, simply omit `return_dataset_traits` (defaults to `False`):
+If you don't need the report returned, simply omit `return_validation_report` (defaults to `False`). The function will raise a `ValueError` if the dataset does not pass the validation.
 
 ```python
-ds = load_dataset(
+ds = load_and_validate_dataset(
     "s3://my-bucket/dataset.zarr",
     loader="mlwp_data_loaders.loaders.anemoi.anemoi_datasets",
     storage_options={"anon": True},
@@ -83,25 +75,20 @@ uv run mlwp.load_and_validate_dataset \
 
 ## Loader Module Contract
 
-Each loader module must define a function and optionally standard profile variables:
+Each loader module must define a function and assign the correct trait profile attributes to the dataset:
 
 1. `load_dataset(path: str | list[str], **kwargs) -> xr.Dataset`
    - **Required**. Handles opening the path(s), preprocessing, concatenating, and postprocessing, returning a single normalized `xarray.Dataset`.
-2. `TIME_PROFILE`: `str`
-   - Defines the time trait profile for `mlwp-data-specs` validation (e.g. `"forecast"`).
-3. `SPACE_PROFILE`: `str`
-   - Defines the space trait profile (e.g. `"grid"`).
-4. `UNCERTAINTY_PROFILE`: `str`
-   - Defines the uncertainty trait profile (e.g. `"deterministic"`).
+2. Attributes attached to the dataset
+   - Must set `mlwp_time_trait` (e.g. `"forecast"`).
+   - Must set `mlwp_space_trait` (e.g. `"grid"`).
+   - Must set `mlwp_uncertainty_trait` (e.g. `"deterministic"`).
 
 ### Example Loader (`my_loader.py`)
 
 ```python
 import xarray as xr
-
-TIME_PROFILE = "observation"
-SPACE_PROFILE = "grid"
-UNCERTAINTY_PROFILE = "deterministic"
+from mlwp_data_loaders.core import SPACE_TRAIT_ATTR, TIME_TRAIT_ATTR, UNCERTAINTY_TRAIT_ATTR
 
 def load_dataset(path: str | list[str], **kwargs) -> xr.Dataset:
     if isinstance(path, list):
@@ -112,6 +99,11 @@ def load_dataset(path: str | list[str], **kwargs) -> xr.Dataset:
     # Example post-processing
     if "time" in ds.dims:
         ds = ds.rename({"time": "valid_time"})
+
+    # Assign required traits for validation
+    ds.attrs[TIME_TRAIT_ATTR] = "observation"
+    ds.attrs[SPACE_TRAIT_ATTR] = "grid"
+    ds.attrs[UNCERTAINTY_TRAIT_ATTR] = "deterministic"
 
     return ds
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ where = ["src"]
 testpaths = ["tests"]
 
 [tool.uv.sources]
-mlwp-data-specs = { git = "https://github.com/mlwp-tools/mlwp-data-specs", rev = "3a7529b" }
 mxalign = { git = "https://github.com/mlwp-tools/mxalign", rev = "e2232d93275c7508897a7ddb0cce8b508665f24c" }
+mlwp-data-specs = { git = "https://github.com/mlwp-tools/mlwp-data-specs", rev = "059f382" }
 
 [dependency-groups]
 dev = [

--- a/src/mlwp_data_loaders/__init__.py
+++ b/src/mlwp_data_loaders/__init__.py
@@ -1,5 +1,5 @@
 """Helpers for loading datasets before validating them with mlwp-data-specs."""
 
-from .api import load_dataset
+from .api import load_and_validate_dataset
 
-__all__ = ["load_dataset"]
+__all__ = ["load_and_validate_dataset"]

--- a/src/mlwp_data_loaders/api.py
+++ b/src/mlwp_data_loaders/api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any
+from typing import Any, Literal, overload
 
 import xarray as xr
 from mlwp_data_specs import validate_dataset
@@ -11,13 +11,38 @@ from mlwp_data_specs import validate_dataset
 from .core import get_dataset_traits_from_loader
 
 
+@overload
 def load_dataset(
     dataset_path: str | list[str],
     *,
     loader: str,
     storage_options: dict[str, Any] | None = None,
+    return_dataset_traits: Literal[False] = False,
     **kwargs: Any,
 ) -> xr.Dataset:
+    ...
+
+
+@overload
+def load_dataset(
+    dataset_path: str | list[str],
+    *,
+    loader: str,
+    storage_options: dict[str, Any] | None = None,
+    return_dataset_traits: Literal[True],
+    **kwargs: Any,
+) -> tuple[xr.Dataset, dict[str, Any]]:
+    ...
+
+
+def load_dataset(
+    dataset_path: str | list[str],
+    *,
+    loader: str,
+    storage_options: dict[str, Any] | None = None,
+    return_dataset_traits: bool = False,
+    **kwargs: Any,
+) -> xr.Dataset | tuple[xr.Dataset, dict[str, Any]]:
     """Load a dataset through a loader module and validate it.
 
     Parameters
@@ -29,18 +54,22 @@ def load_dataset(
         path. A value containing ``.`` is treated as a Python module path.
     storage_options : dict[str, Any] | None, optional
         Storage options forwarded to the loader's ``load_dataset`` function.
+    return_dataset_traits : bool, optional
+        If True, return a tuple containing the dataset and the loader traits.
+        Defaults to False.
     **kwargs
         Additional keyword arguments forwarded to the loader's ``load_dataset``
         function if its signature accepts them.
 
     Returns
     -------
-    xr.Dataset
-        Loaded and validated dataset.
+    xr.Dataset | tuple[xr.Dataset, dict[str, Any]]
+        Loaded and validated dataset. If `return_dataset_traits` is True,
+        returns a tuple of (dataset, dataset_traits).
     """
-    traits = get_dataset_traits_from_loader(loader)
+    dataset_traits = get_dataset_traits_from_loader(loader)
 
-    loader_func = traits["load_dataset"]
+    loader_func = dataset_traits["load_dataset"]
     sig = inspect.signature(loader_func)
 
     loader_kwargs: dict[str, Any] = {}
@@ -65,9 +94,11 @@ def load_dataset(
 
     validate_dataset(
         ds,
-        time=traits.get("time_profile"),
-        space=traits.get("space_profile"),
-        uncertainty=traits.get("uncertainty_profile"),
+        time=dataset_traits.get("time_profile"),
+        space=dataset_traits.get("space_profile"),
+        uncertainty=dataset_traits.get("uncertainty_profile"),
     )
 
+    if return_dataset_traits:
+        return ds, dataset_traits
     return ds

--- a/src/mlwp_data_loaders/api.py
+++ b/src/mlwp_data_loaders/api.py
@@ -3,36 +3,12 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Literal, overload
+from typing import Any
 
 import xarray as xr
 from mlwp_data_specs import validate_dataset
 
 from .core import get_dataset_traits_from_loader
-
-
-@overload
-def load_dataset(
-    dataset_path: str | list[str],
-    *,
-    loader: str,
-    storage_options: dict[str, Any] | None = None,
-    return_dataset_traits: Literal[False] = False,
-    **kwargs: Any,
-) -> xr.Dataset:
-    ...
-
-
-@overload
-def load_dataset(
-    dataset_path: str | list[str],
-    *,
-    loader: str,
-    storage_options: dict[str, Any] | None = None,
-    return_dataset_traits: Literal[True],
-    **kwargs: Any,
-) -> tuple[xr.Dataset, dict[str, Any]]:
-    ...
 
 
 def load_dataset(

--- a/src/mlwp_data_loaders/api.py
+++ b/src/mlwp_data_loaders/api.py
@@ -2,23 +2,27 @@
 
 from __future__ import annotations
 
-import inspect
 from typing import Any
 
 import xarray as xr
 from mlwp_data_specs import validate_dataset
+from mlwp_data_specs.specs.reporting import ValidationReport
 
-from .core import get_dataset_traits_from_loader
+from .core import (
+    SPACE_TRAIT_ATTR,
+    TIME_TRAIT_ATTR,
+    UNCERTAINTY_TRAIT_ATTR,
+    get_loader_func,
+)
 
 
-def load_dataset(
+def load_and_validate_dataset(
     dataset_path: str | list[str],
     *,
     loader: str,
-    storage_options: dict[str, Any] | None = None,
-    return_dataset_traits: bool = False,
+    return_validation_report: bool = False,
     **kwargs: Any,
-) -> xr.Dataset | tuple[xr.Dataset, dict[str, Any]]:
+) -> xr.Dataset | tuple[xr.Dataset, ValidationReport]:
     """Load a dataset through a loader module and validate it.
 
     Parameters
@@ -28,53 +32,56 @@ def load_dataset(
     loader : str
         Loader module reference. A value ending in ``.py`` is treated as a file
         path. A value containing ``.`` is treated as a Python module path.
-    storage_options : dict[str, Any] | None, optional
-        Storage options forwarded to the loader's ``load_dataset`` function.
-    return_dataset_traits : bool, optional
-        If True, return a tuple containing the dataset and the loader traits.
+    return_validation_report : bool, optional
+        If True, return a tuple containing the dataset and the validation report.
         Defaults to False.
     **kwargs
         Additional keyword arguments forwarded to the loader's ``load_dataset``
-        function if its signature accepts them.
+        function (e.g., ``storage_options``).
 
     Returns
     -------
-    xr.Dataset | tuple[xr.Dataset, dict[str, Any]]
-        Loaded and validated dataset. If `return_dataset_traits` is True,
-        returns a tuple of (dataset, dataset_traits).
+    xr.Dataset | tuple[xr.Dataset, ValidationReport]
+        Loaded and validated dataset. If `return_validation_report` is True,
+        returns a tuple of (dataset, validation_report).
+
+    Raises
+    ------
+    ValueError
+        If validation fails and `return_validation_report` is False.
     """
-    dataset_traits = get_dataset_traits_from_loader(loader)
+    loader_func = get_loader_func(loader)
 
-    loader_func = dataset_traits["load_dataset"]
-    sig = inspect.signature(loader_func)
-
-    loader_kwargs: dict[str, Any] = {}
-
-    # Check if the loader's load_dataset accepts **kwargs
-    accepts_kwargs = any(
-        param.kind == inspect.Parameter.VAR_KEYWORD for param in sig.parameters.values()
-    )
-
-    if storage_options is not None:
-        if accepts_kwargs or "storage_options" in sig.parameters:
-            loader_kwargs["storage_options"] = storage_options
-
-    for key, value in kwargs.items():
-        if accepts_kwargs or key in sig.parameters:
-            loader_kwargs[key] = value
-
-    ds = loader_func(dataset_path, **loader_kwargs)
+    ds = loader_func(dataset_path, **kwargs)
 
     if not isinstance(ds, xr.Dataset):
         ds = ds.to_dataset()
 
-    validate_dataset(
+    # All data loaders must explicitly define these three trait attributes
+    # on the returned xarray dataset.
+    try:
+        time_trait = ds.attrs[TIME_TRAIT_ATTR]
+        space_trait = ds.attrs[SPACE_TRAIT_ATTR]
+        uncertainty_trait = ds.attrs[UNCERTAINTY_TRAIT_ATTR]
+    except KeyError as exc:
+        raise ValueError(
+            f"Loader {loader!r} returned a dataset missing required trait attribute: {exc}"
+        ) from exc
+
+    report = validate_dataset(
         ds,
-        time=dataset_traits.get("time_profile"),
-        space=dataset_traits.get("space_profile"),
-        uncertainty=dataset_traits.get("uncertainty_profile"),
+        time=time_trait,
+        space=space_trait,
+        uncertainty=uncertainty_trait,
     )
 
-    if return_dataset_traits:
-        return ds, dataset_traits
+    if return_validation_report:
+        return ds, report
+
+    if report.has_fails():
+        # Ideally, we should be able to format the report nicely
+        raise ValueError(
+            "Dataset validation failed. Run with return_validation_report=True for details."
+        )
+
     return ds

--- a/src/mlwp_data_loaders/api.py
+++ b/src/mlwp_data_loaders/api.py
@@ -8,12 +8,7 @@ import xarray as xr
 from mlwp_data_specs import validate_dataset
 from mlwp_data_specs.specs.reporting import ValidationReport
 
-from .core import (
-    SPACE_TRAIT_ATTR,
-    TIME_TRAIT_ATTR,
-    UNCERTAINTY_TRAIT_ATTR,
-    get_loader_func,
-)
+from .core import get_loader_func
 
 
 def load_and_validate_dataset(
@@ -57,23 +52,7 @@ def load_and_validate_dataset(
     if not isinstance(ds, xr.Dataset):
         ds = ds.to_dataset()
 
-    # All data loaders must explicitly define these three trait attributes
-    # on the returned xarray dataset.
-    try:
-        time_trait = ds.attrs[TIME_TRAIT_ATTR]
-        space_trait = ds.attrs[SPACE_TRAIT_ATTR]
-        uncertainty_trait = ds.attrs[UNCERTAINTY_TRAIT_ATTR]
-    except KeyError as exc:
-        raise ValueError(
-            f"Loader {loader!r} returned a dataset missing required trait attribute: {exc}"
-        ) from exc
-
-    report = validate_dataset(
-        ds,
-        time=time_trait,
-        space=space_trait,
-        uncertainty=uncertainty_trait,
-    )
+    report = validate_dataset(ds)
 
     if return_validation_report:
         return ds, report

--- a/src/mlwp_data_loaders/cli.py
+++ b/src/mlwp_data_loaders/cli.py
@@ -10,8 +10,6 @@ from mlwp_data_specs import __version__ as specs_version
 from mlwp_data_specs.api import validate_dataset
 
 from .api import load_dataset
-from .core import get_dataset_traits_from_loader
-from .mxalign_api import validate_dataset_with_mxalign
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -79,27 +77,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger.info(f"Using mlwp-data-specs {specs_version}")
 
     # Load the dataset
-    ds = load_dataset(
+    res = load_dataset(
         dataset_input,
         loader=args.loader,
         storage_options=storage_options or None,
+        return_dataset_traits=True,
     )
+    assert isinstance(res, tuple)
+    ds, dataset_traits = res
 
-    # Re-run validation to get the report for printing
-    traits = get_dataset_traits_from_loader(args.loader)
-
-    time_profile = traits.get("time_profile")
-    space_profile = traits.get("space_profile")
-    uncertainty_profile = traits.get("uncertainty_profile")
+    time_profile = dataset_traits.get("time_profile")
+    space_profile = dataset_traits.get("space_profile")
+    uncertainty_profile = dataset_traits.get("uncertainty_profile")
 
     report = validate_dataset(
-        ds,
-        time=time_profile,
-        space=space_profile,
-        uncertainty=uncertainty_profile,
-    )
-
-    report += validate_dataset_with_mxalign(
         ds,
         time=time_profile,
         space=space_profile,

--- a/src/mlwp_data_loaders/cli.py
+++ b/src/mlwp_data_loaders/cli.py
@@ -77,14 +77,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger.info(f"Using mlwp-data-specs {specs_version}")
 
     # Load the dataset
-    res = load_dataset(
+    ds, dataset_traits = load_dataset(  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
         dataset_input,
         loader=args.loader,
         storage_options=storage_options or None,
         return_dataset_traits=True,
     )
-    assert isinstance(res, tuple)
-    ds, dataset_traits = res
 
     time_profile = dataset_traits.get("time_profile")
     space_profile = dataset_traits.get("space_profile")

--- a/src/mlwp_data_loaders/cli.py
+++ b/src/mlwp_data_loaders/cli.py
@@ -7,9 +7,8 @@ from collections.abc import Sequence
 
 from loguru import logger
 from mlwp_data_specs import __version__ as specs_version
-from mlwp_data_specs.api import validate_dataset
 
-from .api import load_dataset
+from .api import load_and_validate_dataset
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -76,23 +75,16 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     logger.info(f"Using mlwp-data-specs {specs_version}")
 
+    kwargs = {}
+    if storage_options:
+        kwargs["storage_options"] = storage_options
+
     # Load the dataset
-    ds, dataset_traits = load_dataset(  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
+    ds, report = load_and_validate_dataset(  # type: ignore
         dataset_input,
         loader=args.loader,
-        storage_options=storage_options or None,
-        return_dataset_traits=True,
-    )
-
-    time_profile = dataset_traits.get("time_profile")
-    space_profile = dataset_traits.get("space_profile")
-    uncertainty_profile = dataset_traits.get("uncertainty_profile")
-
-    report = validate_dataset(
-        ds,
-        time=time_profile,
-        space=space_profile,
-        uncertainty=uncertainty_profile,
+        return_validation_report=True,
+        **kwargs,
     )
 
     report.console_print()

--- a/src/mlwp_data_loaders/core.py
+++ b/src/mlwp_data_loaders/core.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 import importlib
 import importlib.util
 from pathlib import Path
-from types import ModuleType
-from typing import Any
+from typing import Any, Callable
 
-DatasetTraits = dict[str, Any]
+_TRAIT_ATTR_FORMAT = "mlwp_{}_trait"
+
+TIME_TRAIT_ATTR = _TRAIT_ATTR_FORMAT.format("time")
+SPACE_TRAIT_ATTR = _TRAIT_ATTR_FORMAT.format("space")
+UNCERTAINTY_TRAIT_ATTR = _TRAIT_ATTR_FORMAT.format("uncertainty")
 
 
-def _load_module(loader: str) -> ModuleType:
-    """Import a loader module from a Python file or module path.
+def get_loader_func(loader: str) -> Callable[..., Any]:
+    """Get the load_dataset function from a loader module.
 
     Parameters
     ----------
@@ -22,13 +25,14 @@ def _load_module(loader: str) -> ModuleType:
 
     Returns
     -------
-    ModuleType
-        Imported module object.
+    Callable
+        The load_dataset function.
 
     Raises
     ------
     ValueError
-        If the loader reference cannot be resolved.
+        If the loader reference cannot be resolved or if the loader module
+        does not define a 'load_dataset' function.
     """
     if loader.endswith(".py"):
         path = Path(loader)
@@ -37,48 +41,15 @@ def _load_module(loader: str) -> ModuleType:
             raise ValueError(f"Could not import loader module from file: {loader}")
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-        return module
-    if "." in loader:
-        return importlib.import_module(loader)
-    raise ValueError(
-        "Loader must be a Python file path ending in .py or a Python module path"
-    )
-
-
-def get_dataset_traits_from_loader(loader: str) -> DatasetTraits:
-    """Import traits from a loader module.
-
-    Parameters
-    ----------
-    loader : str
-        Loader module reference.
-
-    Returns
-    -------
-    DatasetTraits
-        Mapping with trait names normalized to lowercase.
-
-    Raises
-    ------
-    ValueError
-        If the loader module does not define a 'load_dataset' function.
-    """
-    module = _load_module(loader)
-    traits: DatasetTraits = {}
+    elif "." in loader:
+        module = importlib.import_module(loader)
+    else:
+        raise ValueError(
+            "Loader must be a Python file path ending in .py or a Python module path"
+        )
 
     if not hasattr(module, "load_dataset"):
         raise ValueError(
             f"Loader module {loader!r} must define a 'load_dataset' function."
         )
-    traits["load_dataset"] = module.load_dataset
-
-    supported_traits = (
-        "TIME_PROFILE",
-        "SPACE_PROFILE",
-        "UNCERTAINTY_PROFILE",
-    )
-    for name in supported_traits:
-        if hasattr(module, name):
-            traits[name.lower()] = getattr(module, name)
-
-    return traits
+    return module.load_dataset

--- a/src/mlwp_data_loaders/core.py
+++ b/src/mlwp_data_loaders/core.py
@@ -7,12 +7,6 @@ import importlib.util
 from pathlib import Path
 from typing import Any, Callable
 
-_TRAIT_ATTR_FORMAT = "mlwp_{}_trait"
-
-TIME_TRAIT_ATTR = _TRAIT_ATTR_FORMAT.format("time")
-SPACE_TRAIT_ATTR = _TRAIT_ATTR_FORMAT.format("space")
-UNCERTAINTY_TRAIT_ATTR = _TRAIT_ATTR_FORMAT.format("uncertainty")
-
 
 def get_loader_func(loader: str) -> Callable[..., Any]:
     """Get the load_dataset function from a loader module.

--- a/src/mlwp_data_loaders/loaders/anemoi/anemoi_datasets.py
+++ b/src/mlwp_data_loaders/loaders/anemoi/anemoi_datasets.py
@@ -4,9 +4,11 @@ import numpy as np
 import xarray as xr
 from loguru import logger
 
-TIME_PROFILE = "observation"
-SPACE_PROFILE = "grid"
-UNCERTAINTY_PROFILE = "deterministic"
+from mlwp_data_loaders.core import (
+    SPACE_TRAIT_ATTR,
+    TIME_TRAIT_ATTR,
+    UNCERTAINTY_TRAIT_ATTR,
+)
 
 DROP_VARS = [
     "latitude",
@@ -78,7 +80,11 @@ def load_dataset(
                 f"to xr.Dataset, this might take some time. Consider selecting the relevant variables during loading"
             )
 
-    return ds_selected.to_dataset(dim="variable")
+    ds_final = ds_selected.to_dataset(dim="variable")
+    ds_final.attrs[TIME_TRAIT_ATTR] = "observation"
+    ds_final.attrs[SPACE_TRAIT_ATTR] = "grid"
+    ds_final.attrs[UNCERTAINTY_TRAIT_ATTR] = "deterministic"
+    return ds_final
 
 
 def _postprocess(dataset: xr.Dataset) -> xr.Dataset:

--- a/src/mlwp_data_loaders/loaders/anemoi/anemoi_datasets.py
+++ b/src/mlwp_data_loaders/loaders/anemoi/anemoi_datasets.py
@@ -3,8 +3,7 @@ from typing import Any
 import numpy as np
 import xarray as xr
 from loguru import logger
-
-from mlwp_data_loaders.core import (
+from mlwp_data_specs.api import (
     SPACE_TRAIT_ATTR,
     TIME_TRAIT_ATTR,
     UNCERTAINTY_TRAIT_ATTR,

--- a/src/mlwp_data_loaders/loaders/anemoi/anemoi_inference.py
+++ b/src/mlwp_data_loaders/loaders/anemoi/anemoi_inference.py
@@ -1,8 +1,7 @@
 from typing import Any
 
 import xarray as xr
-
-from mlwp_data_loaders.core import (
+from mlwp_data_specs.api import (
     SPACE_TRAIT_ATTR,
     TIME_TRAIT_ATTR,
     UNCERTAINTY_TRAIT_ATTR,

--- a/src/mlwp_data_loaders/loaders/anemoi/anemoi_inference.py
+++ b/src/mlwp_data_loaders/loaders/anemoi/anemoi_inference.py
@@ -2,9 +2,11 @@ from typing import Any
 
 import xarray as xr
 
-TIME_PROFILE = "forecast"
-SPACE_PROFILE = "grid"
-UNCERTAINTY_PROFILE = "deterministic"
+from mlwp_data_loaders.core import (
+    SPACE_TRAIT_ATTR,
+    TIME_TRAIT_ATTR,
+    UNCERTAINTY_TRAIT_ATTR,
+)
 
 
 def load_dataset(
@@ -58,6 +60,10 @@ def load_dataset(
         .rename_dims({"values": "grid_index"})
         .swap_dims({"time": "lead_time"})
     )
+
+    ds_out.attrs[TIME_TRAIT_ATTR] = "forecast"
+    ds_out.attrs[SPACE_TRAIT_ATTR] = "grid"
+    ds_out.attrs[UNCERTAINTY_TRAIT_ATTR] = "deterministic"
 
     return ds_out
 

--- a/src/mlwp_data_loaders/loaders/harp/obstable.py
+++ b/src/mlwp_data_loaders/loaders/harp/obstable.py
@@ -7,9 +7,11 @@ import sqlite3
 import pandas as pd
 import xarray as xr
 
-TIME_PROFILE = "observation"
-SPACE_PROFILE = "point"
-UNCERTAINTY_PROFILE = "deterministic"
+from mlwp_data_loaders.core import (
+    SPACE_TRAIT_ATTR,
+    TIME_TRAIT_ATTR,
+    UNCERTAINTY_TRAIT_ATTR,
+)
 
 COORDS = {
     "longitude": "lon",
@@ -100,6 +102,12 @@ def load_dataset(
         {"standard_name": "longitude", "units": "degrees_east"}
     )
 
-    return ds.rename_dims({"code": "point_index"}).transpose(
+    ds_final = ds.rename_dims({"code": "point_index"}).transpose(
         "valid_time", "point_index"
     )
+
+    ds_final.attrs[TIME_TRAIT_ATTR] = "observation"
+    ds_final.attrs[SPACE_TRAIT_ATTR] = "point"
+    ds_final.attrs[UNCERTAINTY_TRAIT_ATTR] = "deterministic"
+
+    return ds_final

--- a/src/mlwp_data_loaders/loaders/harp/obstable.py
+++ b/src/mlwp_data_loaders/loaders/harp/obstable.py
@@ -6,8 +6,7 @@ import sqlite3
 
 import pandas as pd
 import xarray as xr
-
-from mlwp_data_loaders.core import (
+from mlwp_data_specs.api import (
     SPACE_TRAIT_ATTR,
     TIME_TRAIT_ATTR,
     UNCERTAINTY_TRAIT_ATTR,

--- a/tests/test_anemoi_datasets_integration.py
+++ b/tests/test_anemoi_datasets_integration.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from mlwp_data_specs import validate_dataset
 
 from mlwp_data_loaders.api import load_dataset
-from mlwp_data_loaders.core import get_dataset_traits_from_loader
 from mlwp_data_loaders.mxalign_api import validate_dataset_with_mxalign
 
 # Use small CERRA sample dataset stored on EWC (European Weather Cloud)
@@ -25,14 +24,13 @@ def test_load_dataset_opens_anemoi_store_from_ewc() -> None:
         "anon": True,
     }
 
-    ds = load_dataset(
+    ds, traits = load_dataset(
         DATASET_PATH,
         loader=LOADER,
         storage_options=storage_options,
         chunks=None,
+        return_dataset_traits=True,
     )
-
-    traits = get_dataset_traits_from_loader(LOADER)
 
     report_mxalign = validate_dataset_with_mxalign(
         ds,

--- a/tests/test_anemoi_datasets_integration.py
+++ b/tests/test_anemoi_datasets_integration.py
@@ -24,7 +24,7 @@ def test_load_dataset_opens_anemoi_store_from_ewc() -> None:
         "anon": True,
     }
 
-    ds, traits = load_dataset(  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
+    ds, dataset_traits = load_dataset(  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
         DATASET_PATH,
         loader=LOADER,
         storage_options=storage_options,
@@ -36,9 +36,9 @@ def test_load_dataset_opens_anemoi_store_from_ewc() -> None:
     # to ensure `mlwp-data-specs` behaves identically. It will eventually be removed.
     report_mxalign = validate_dataset_with_mxalign(
         ds,
-        time=traits.get("time_profile"),
-        space=traits.get("space_profile"),
-        uncertainty=traits.get("uncertainty_profile"),
+        time=dataset_traits.get("time_profile"),
+        space=dataset_traits.get("space_profile"),
+        uncertainty=dataset_traits.get("uncertainty_profile"),
     )
     if report_mxalign.has_fails():
         report_mxalign.console_print()
@@ -46,9 +46,9 @@ def test_load_dataset_opens_anemoi_store_from_ewc() -> None:
 
     report_specs = validate_dataset(
         ds,
-        time=traits.get("time_profile"),
-        space=traits.get("space_profile"),
-        uncertainty=traits.get("uncertainty_profile"),
+        time=dataset_traits.get("time_profile"),
+        space=dataset_traits.get("space_profile"),
+        uncertainty=dataset_traits.get("uncertainty_profile"),
     )
     if report_specs.has_fails():
         report_specs.console_print()

--- a/tests/test_anemoi_datasets_integration.py
+++ b/tests/test_anemoi_datasets_integration.py
@@ -24,7 +24,7 @@ def test_load_dataset_opens_anemoi_store_from_ewc() -> None:
         "anon": True,
     }
 
-    ds, traits = load_dataset(
+    ds, traits = load_dataset(  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
         DATASET_PATH,
         loader=LOADER,
         storage_options=storage_options,
@@ -32,6 +32,8 @@ def test_load_dataset_opens_anemoi_store_from_ewc() -> None:
         return_dataset_traits=True,
     )
 
+    # Note: mxalign validation is temporarily kept here during early development
+    # to ensure `mlwp-data-specs` behaves identically. It will eventually be removed.
     report_mxalign = validate_dataset_with_mxalign(
         ds,
         time=traits.get("time_profile"),

--- a/tests/test_anemoi_datasets_integration.py
+++ b/tests/test_anemoi_datasets_integration.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from mlwp_data_specs import validate_dataset
-
-from mlwp_data_loaders.api import load_dataset
+from mlwp_data_loaders.api import load_and_validate_dataset
+from mlwp_data_loaders.core import (
+    SPACE_TRAIT_ATTR,
+    TIME_TRAIT_ATTR,
+    UNCERTAINTY_TRAIT_ATTR,
+)
 from mlwp_data_loaders.mxalign_api import validate_dataset_with_mxalign
 
 # Use small CERRA sample dataset stored on EWC (European Weather Cloud)
@@ -24,32 +27,26 @@ def test_load_dataset_opens_anemoi_store_from_ewc() -> None:
         "anon": True,
     }
 
-    ds, dataset_traits = load_dataset(  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
+    ds, report_specs = load_and_validate_dataset(  # type: ignore
         DATASET_PATH,
         loader=LOADER,
         storage_options=storage_options,
         chunks=None,
-        return_dataset_traits=True,
+        return_validation_report=True,
     )
 
     # Note: mxalign validation is temporarily kept here during early development
     # to ensure `mlwp-data-specs` behaves identically. It will eventually be removed.
     report_mxalign = validate_dataset_with_mxalign(
         ds,
-        time=dataset_traits.get("time_profile"),
-        space=dataset_traits.get("space_profile"),
-        uncertainty=dataset_traits.get("uncertainty_profile"),
+        time=ds.attrs.get(TIME_TRAIT_ATTR),
+        space=ds.attrs.get(SPACE_TRAIT_ATTR),
+        uncertainty=ds.attrs.get(UNCERTAINTY_TRAIT_ATTR),
     )
     if report_mxalign.has_fails():
         report_mxalign.console_print()
     assert not report_mxalign.has_fails()
 
-    report_specs = validate_dataset(
-        ds,
-        time=dataset_traits.get("time_profile"),
-        space=dataset_traits.get("space_profile"),
-        uncertainty=dataset_traits.get("uncertainty_profile"),
-    )
     if report_specs.has_fails():
         report_specs.console_print()
     assert not report_specs.has_fails()

--- a/tests/test_anemoi_datasets_integration.py
+++ b/tests/test_anemoi_datasets_integration.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from mlwp_data_loaders.api import load_and_validate_dataset
-from mlwp_data_loaders.core import (
+from mlwp_data_specs.api import (
     SPACE_TRAIT_ATTR,
     TIME_TRAIT_ATTR,
     UNCERTAINTY_TRAIT_ATTR,
 )
+
+from mlwp_data_loaders.api import load_and_validate_dataset
 from mlwp_data_loaders.mxalign_api import validate_dataset_with_mxalign
 
 # Use small CERRA sample dataset stored on EWC (European Weather Cloud)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -82,9 +82,38 @@ def test_load_dataset_filters_kwargs(tmp_path, monkeypatch: pytest.MonkeyPatch) 
         engine="h5netcdf",  # Should be ignored because strict load_dataset doesn't take 'engine'
         storage_options={"anon": True},  # Should be ignored
     )
+    assert isinstance(ds, xr.Dataset)
 
     assert ds.attrs["chunks"] == "auto"
     assert "engine" not in ds.attrs
+
+
+def test_load_dataset_returns_traits(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check that api.load_dataset returns traits when requested."""
+    loader_file = tmp_path / "loader_traits.py"
+    loader_file.write_text(
+        "def load_dataset(path, **kwargs):\n"
+        "    from xarray import Dataset\n"
+        "    return Dataset()\n"
+        "TIME_PROFILE = 'forecast'\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "mlwp_data_loaders.api.validate_dataset", lambda *args, **kwargs: None
+    )
+
+    res = load_dataset(
+        "dummy.nc",
+        loader=str(loader_file),
+        return_dataset_traits=True,
+    )
+    assert isinstance(res, tuple)
+
+    ds, dataset_traits = res
+    assert isinstance(ds, xr.Dataset)
+    assert isinstance(dataset_traits, dict)
+    assert dataset_traits.get("time_profile") == "forecast"
 
 
 def test_validate_dataset_with_mxalign_returns_fail_report_for_invalid_dims(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -110,7 +110,7 @@ def test_load_dataset_returns_traits(tmp_path, monkeypatch: pytest.MonkeyPatch) 
     )
     assert isinstance(res, tuple)
 
-    ds, dataset_traits = res
+    ds, dataset_traits = res  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
     assert isinstance(ds, xr.Dataset)
     assert isinstance(dataset_traits, dict)
     assert dataset_traits.get("time_profile") == "forecast"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,8 +6,8 @@ import pytest
 import xarray as xr
 
 import mlwp_data_loaders.mxalign_api as mxalign_api
-from mlwp_data_loaders.api import load_dataset
-from mlwp_data_loaders.core import get_dataset_traits_from_loader
+from mlwp_data_loaders.api import load_and_validate_dataset
+from mlwp_data_loaders.core import get_loader_func
 
 
 def _forecast_grid_ds() -> xr.Dataset:
@@ -33,87 +33,82 @@ def _forecast_grid_ds() -> xr.Dataset:
     return ds
 
 
-def test_get_dataset_traits_from_loader_raises_missing_load_dataset(tmp_path) -> None:
+def test_get_loader_func_raises_missing_load_dataset(tmp_path) -> None:
     """Loader modules must define a 'load_dataset' function."""
     loader_file = tmp_path / "loader_missing.py"
     loader_file.write_text("TIME_PROFILE = 'forecast'\n", encoding="utf-8")
     with pytest.raises(ValueError, match="must define a 'load_dataset' function"):
-        get_dataset_traits_from_loader(str(loader_file))
+        get_loader_func(str(loader_file))
 
 
-def test_get_dataset_traits_from_loader_finds_constants(tmp_path) -> None:
-    """Loader modules can define trait constants which are correctly captured."""
-    loader_file = tmp_path / "loader_valid.py"
-    loader_file.write_text(
-        "def load_dataset(path, **kwargs): return None\n"
-        "TIME_PROFILE = 'forecast'\n"
-        "SPACE_PROFILE = 'grid'\n",
-        encoding="utf-8",
-    )
-    traits = get_dataset_traits_from_loader(str(loader_file))
-    assert "load_dataset" in traits
-    assert traits["time_profile"] == "forecast"
-    assert traits["space_profile"] == "grid"
-    assert "uncertainty_profile" not in traits
-
-
-def test_load_dataset_filters_kwargs(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Check that api.load_dataset filters kwargs based on loader signature."""
+def test_load_dataset_rejects_unsupported_kwargs(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Check that api.load_dataset rejects kwargs not supported by the loader."""
     loader_file = tmp_path / "loader_strict.py"
     loader_file.write_text(
         "def load_dataset(path, chunks=None):\n"
         "    from xarray import Dataset\n"
         "    ds = Dataset()\n"
         "    ds.attrs['chunks'] = chunks\n"
-        "    return ds\n"
-        "TIME_PROFILE = 'forecast'\n",
+        "    ds.attrs['mlwp_time_trait'] = 'forecast'\n"
+        "    ds.attrs['mlwp_space_trait'] = 'grid'\n"
+        "    ds.attrs['mlwp_uncertainty_trait'] = 'deterministic'\n"
+        "    return ds\n",
         encoding="utf-8",
     )
 
+    class MockReport:
+        def has_fails(self):
+            return False
+
     # Mock validate_dataset to bypass validation on an empty dataset
     monkeypatch.setattr(
-        "mlwp_data_loaders.api.validate_dataset", lambda *args, **kwargs: None
+        "mlwp_data_loaders.api.validate_dataset", lambda *args, **kwargs: MockReport()
     )
 
-    ds = load_dataset(
-        "dummy.nc",
-        loader=str(loader_file),
-        chunks="auto",
-        engine="h5netcdf",  # Should be ignored because strict load_dataset doesn't take 'engine'
-        storage_options={"anon": True},  # Should be ignored
-    )
-    assert isinstance(ds, xr.Dataset)
-
-    assert ds.attrs["chunks"] == "auto"
-    assert "engine" not in ds.attrs
+    with pytest.raises(TypeError, match="unexpected keyword argument 'engine'"):
+        load_and_validate_dataset(
+            "dummy.nc",
+            loader=str(loader_file),
+            chunks="auto",
+            engine="h5netcdf",  # Should raise TypeError
+        )
 
 
-def test_load_dataset_returns_traits(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Check that api.load_dataset returns traits when requested."""
+def test_load_dataset_returns_report(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check that load_and_validate_dataset returns report when requested."""
     loader_file = tmp_path / "loader_traits.py"
     loader_file.write_text(
         "def load_dataset(path, **kwargs):\n"
         "    from xarray import Dataset\n"
-        "    return Dataset()\n"
-        "TIME_PROFILE = 'forecast'\n",
+        "    ds = Dataset()\n"
+        "    ds.attrs['mlwp_time_trait'] = 'forecast'\n"
+        "    ds.attrs['mlwp_space_trait'] = 'grid'\n"
+        "    ds.attrs['mlwp_uncertainty_trait'] = 'deterministic'\n"
+        "    return ds\n",
         encoding="utf-8",
     )
 
+    class MockReport:
+        def has_fails(self):
+            return False
+
     monkeypatch.setattr(
-        "mlwp_data_loaders.api.validate_dataset", lambda *args, **kwargs: None
+        "mlwp_data_loaders.api.validate_dataset", lambda *args, **kwargs: MockReport()
     )
 
-    res = load_dataset(
+    res = load_and_validate_dataset(
         "dummy.nc",
         loader=str(loader_file),
-        return_dataset_traits=True,
+        return_validation_report=True,
     )
     assert isinstance(res, tuple)
 
-    ds, dataset_traits = res  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
+    ds, report = res  # type: ignore
     assert isinstance(ds, xr.Dataset)
-    assert isinstance(dataset_traits, dict)
-    assert dataset_traits.get("time_profile") == "forecast"
+    assert not report.has_fails()
+    assert ds.attrs.get("mlwp_time_trait") == "forecast"
 
 
 def test_validate_dataset_with_mxalign_returns_fail_report_for_invalid_dims(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,14 +37,13 @@ def test_cli_accepts_multiple_dataset_paths(monkeypatch: MonkeyPatch) -> None:
 
     def _load_dataset(dataset_path, **kwargs):
         observed["dataset_path"] = dataset_path
+        if kwargs.get("return_dataset_traits"):
+            return _forecast_grid_ds(), {
+                "time_profile": "forecast",
+                "space_profile": "grid",
+                "uncertainty_profile": "deterministic",
+            }
         return _forecast_grid_ds()
-
-    def _get_dataset_traits_from_loader(loader):
-        return {
-            "time_profile": "forecast",
-            "space_profile": "grid",
-            "uncertainty_profile": "deterministic",
-        }
 
     class _Report:
         def __init__(self):
@@ -63,13 +62,7 @@ def test_cli_accepts_multiple_dataset_paths(monkeypatch: MonkeyPatch) -> None:
         return _Report()
 
     monkeypatch.setattr(cli, "load_dataset", _load_dataset)
-    monkeypatch.setattr(
-        cli, "get_dataset_traits_from_loader", _get_dataset_traits_from_loader
-    )
     monkeypatch.setattr(cli, "validate_dataset", _validate_dataset)
-    monkeypatch.setattr(
-        cli, "validate_dataset_with_mxalign", lambda *args, **kwargs: _Report()
-    )
 
     code = cli.main(
         [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,16 +35,6 @@ def test_cli_accepts_multiple_dataset_paths(monkeypatch: MonkeyPatch) -> None:
     """CLI passes multiple dataset paths through to the load/validate API."""
     observed: dict[str, object] = {}
 
-    def _load_dataset(dataset_path, **kwargs):
-        observed["dataset_path"] = dataset_path
-        if kwargs.get("return_dataset_traits"):
-            return _forecast_grid_ds(), {
-                "time_profile": "forecast",
-                "space_profile": "grid",
-                "uncertainty_profile": "deterministic",
-            }
-        return _forecast_grid_ds()
-
     class _Report:
         def __init__(self):
             self.fails = False
@@ -58,11 +48,13 @@ def test_cli_accepts_multiple_dataset_paths(monkeypatch: MonkeyPatch) -> None:
         def __iadd__(self, other):
             return self
 
-    def _validate_dataset(ds, **kwargs):
-        return _Report()
+    def _load_and_validate_dataset(dataset_path, **kwargs):
+        observed["dataset_path"] = dataset_path
+        if kwargs.get("return_validation_report"):
+            return _forecast_grid_ds(), _Report()
+        return _forecast_grid_ds()
 
-    monkeypatch.setattr(cli, "load_dataset", _load_dataset)
-    monkeypatch.setattr(cli, "validate_dataset", _validate_dataset)
+    monkeypatch.setattr(cli, "load_and_validate_dataset", _load_and_validate_dataset)
 
     code = cli.main(
         [

--- a/tests/test_harp_obstable_integration.py
+++ b/tests/test_harp_obstable_integration.py
@@ -7,7 +7,6 @@ import pytest
 from mlwp_data_specs import validate_dataset
 
 from mlwp_data_loaders.api import load_dataset
-from mlwp_data_loaders.core import get_dataset_traits_from_loader
 from mlwp_data_loaders.mxalign_api import validate_dataset_with_mxalign
 
 HARP_DATA_URL = "https://raw.githubusercontent.com/harphub/harpData/master/inst/OBSTABLE/OBSTABLE_2019.sqlite"
@@ -26,13 +25,14 @@ def obstable_path() -> str:
 
 def test_load_dataset_opens_harp_obstable(obstable_path: str) -> None:
     """The harp.obstable loader can open and validate the sample SQLite file."""
-    ds = load_dataset(
+    ds, traits = load_dataset(  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
         obstable_path,
         loader=LOADER,
+        return_dataset_traits=True,
     )
 
-    traits = get_dataset_traits_from_loader(LOADER)
-
+    # Note: mxalign validation is temporarily kept here during early development
+    # to ensure `mlwp-data-specs` behaves identically. It will eventually be removed.
     report_mxalign = validate_dataset_with_mxalign(
         ds,
         time=traits.get("time_profile"),

--- a/tests/test_harp_obstable_integration.py
+++ b/tests/test_harp_obstable_integration.py
@@ -25,7 +25,7 @@ def obstable_path() -> str:
 
 def test_load_dataset_opens_harp_obstable(obstable_path: str) -> None:
     """The harp.obstable loader can open and validate the sample SQLite file."""
-    ds, traits = load_dataset(  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
+    ds, dataset_traits = load_dataset(  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
         obstable_path,
         loader=LOADER,
         return_dataset_traits=True,
@@ -35,9 +35,9 @@ def test_load_dataset_opens_harp_obstable(obstable_path: str) -> None:
     # to ensure `mlwp-data-specs` behaves identically. It will eventually be removed.
     report_mxalign = validate_dataset_with_mxalign(
         ds,
-        time=traits.get("time_profile"),
-        space=traits.get("space_profile"),
-        uncertainty=traits.get("uncertainty_profile"),
+        time=dataset_traits.get("time_profile"),
+        space=dataset_traits.get("space_profile"),
+        uncertainty=dataset_traits.get("uncertainty_profile"),
     )
     if report_mxalign.has_fails():
         report_mxalign.console_print()
@@ -45,9 +45,9 @@ def test_load_dataset_opens_harp_obstable(obstable_path: str) -> None:
 
     report_specs = validate_dataset(
         ds,
-        time=traits.get("time_profile"),
-        space=traits.get("space_profile"),
-        uncertainty=traits.get("uncertainty_profile"),
+        time=dataset_traits.get("time_profile"),
+        space=dataset_traits.get("space_profile"),
+        uncertainty=dataset_traits.get("uncertainty_profile"),
     )
     if report_specs.has_fails():
         report_specs.console_print()

--- a/tests/test_harp_obstable_integration.py
+++ b/tests/test_harp_obstable_integration.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import pooch
 import pytest
-
-from mlwp_data_loaders.api import load_and_validate_dataset
-from mlwp_data_loaders.core import (
+from mlwp_data_specs.api import (
     SPACE_TRAIT_ATTR,
     TIME_TRAIT_ATTR,
     UNCERTAINTY_TRAIT_ATTR,
 )
+
+from mlwp_data_loaders.api import load_and_validate_dataset
 from mlwp_data_loaders.mxalign_api import validate_dataset_with_mxalign
 
 HARP_DATA_URL = "https://raw.githubusercontent.com/harphub/harpData/master/inst/OBSTABLE/OBSTABLE_2019.sqlite"

--- a/tests/test_harp_obstable_integration.py
+++ b/tests/test_harp_obstable_integration.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import pooch
 import pytest
-from mlwp_data_specs import validate_dataset
 
-from mlwp_data_loaders.api import load_dataset
+from mlwp_data_loaders.api import load_and_validate_dataset
+from mlwp_data_loaders.core import (
+    SPACE_TRAIT_ATTR,
+    TIME_TRAIT_ATTR,
+    UNCERTAINTY_TRAIT_ATTR,
+)
 from mlwp_data_loaders.mxalign_api import validate_dataset_with_mxalign
 
 HARP_DATA_URL = "https://raw.githubusercontent.com/harphub/harpData/master/inst/OBSTABLE/OBSTABLE_2019.sqlite"
@@ -25,30 +29,24 @@ def obstable_path() -> str:
 
 def test_load_dataset_opens_harp_obstable(obstable_path: str) -> None:
     """The harp.obstable loader can open and validate the sample SQLite file."""
-    ds, dataset_traits = load_dataset(  # type: ignore  # load_dataset returns a tuple when return_dataset_traits=True
+    ds, report_specs = load_and_validate_dataset(  # type: ignore
         obstable_path,
         loader=LOADER,
-        return_dataset_traits=True,
+        return_validation_report=True,
     )
 
     # Note: mxalign validation is temporarily kept here during early development
     # to ensure `mlwp-data-specs` behaves identically. It will eventually be removed.
     report_mxalign = validate_dataset_with_mxalign(
         ds,
-        time=dataset_traits.get("time_profile"),
-        space=dataset_traits.get("space_profile"),
-        uncertainty=dataset_traits.get("uncertainty_profile"),
+        time=ds.attrs.get(TIME_TRAIT_ATTR),
+        space=ds.attrs.get(SPACE_TRAIT_ATTR),
+        uncertainty=ds.attrs.get(UNCERTAINTY_TRAIT_ATTR),
     )
     if report_mxalign.has_fails():
         report_mxalign.console_print()
     assert not report_mxalign.has_fails()
 
-    report_specs = validate_dataset(
-        ds,
-        time=dataset_traits.get("time_profile"),
-        space=dataset_traits.get("space_profile"),
-        uncertainty=dataset_traits.get("uncertainty_profile"),
-    )
     if report_specs.has_fails():
         report_specs.console_print()
     assert not report_specs.has_fails()

--- a/uv.lock
+++ b/uv.lock
@@ -1450,7 +1450,7 @@ requires-dist = [
     { name = "fsspec" },
     { name = "h5netcdf" },
     { name = "loguru" },
-    { name = "mlwp-data-specs", git = "https://github.com/mlwp-tools/mlwp-data-specs?rev=3a7529b" },
+    { name = "mlwp-data-specs", git = "https://github.com/mlwp-tools/mlwp-data-specs?rev=059f382" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "s3fs" },
     { name = "xarray" },
@@ -1473,7 +1473,7 @@ test = [
 [[package]]
 name = "mlwp-data-specs"
 version = "0.1.0"
-source = { git = "https://github.com/mlwp-tools/mlwp-data-specs?rev=3a7529b#3a7529bbaa32ab705b0feb24f0d3928e98f99029" }
+source = { git = "https://github.com/mlwp-tools/mlwp-data-specs?rev=059f382#059f3820134e0ebff4deb9180dc5a0da18399289" }
 dependencies = [
     { name = "fsspec" },
     { name = "loguru" },


### PR DESCRIPTION
This PR refactors the loading API to [allow loaders to dynamically set dataset traits based on the contents of the loaded data](https://github.com/mlwp-tools/mlwp-data-loaders/issues/5). These dataset traits are set as global attributes in the format `mlwp_{trait_name}_trait` e.g. `mlwp_space_trait`. [mlwp-data-specs was recently changed](https://github.com/mlwp-tools/mlwp-data-specs) to support the use of these trait values directly from dataset attributes (as well as through call arguments to `mlwp_data_specs.validate_dataset(ds=ds, ...)`).

As decided on https://github.com/mlwp-tools/mlwp-data-loaders/issues/5#issuecomment-4242581218 `mlwp-data-loaders` always calls the validator (e.g. `mlwp_data_specs.validate_dataset(ds)`) directly on the loaded dataset, without needing to extract traits and pass them as separate keyword arguments. Because `mlwp-data-loaders` also applies validation now the main API function has been renamed from `load_dataset` to `load_and_validate_dataset` to reflect this change.

Implements changes agreed on in https://github.com/mlwp-tools/mlwp-data-loaders/issues/5